### PR TITLE
Add CBBlueLightClient.isNightShiftEnabled

### DIFF
--- a/Shifty/CBBlueLightClient.h
+++ b/Shifty/CBBlueLightClient.h
@@ -20,4 +20,5 @@
 - (BOOL)setEnabled:(BOOL)enabled;
 - (BOOL)getStrength:(float*)strength;
 - (BOOL)getCCT:(float*)arg1;
+- (BOOL)getBlueLightStatus:(struct { BOOL x1; BOOL x2; BOOL x3; int x4; struct { struct { int x_1_2_1; int x_1_2_2; } x_5_1_1; struct { int x_2_2_1; int x_2_2_2; } x_5_1_2; } x5; unsigned long x6; }*)arg1;
 @end

--- a/Shifty/StatusMenuController.swift
+++ b/Shifty/StatusMenuController.swift
@@ -16,11 +16,29 @@ extension CBBlueLightClient {
         self.getStrength(&strength)
         return strength
     }
+    
     var CCT: Float {
         var CCT: Float = 0.0
         self.getCCT(&CCT)
         return CCT
     }
+    
+    var isNightShiftEnabled: Bool {
+        //create an empty mutable OpaquePointer
+        let string = "0000000000"
+        var data = string.data(using: .utf8)!
+        let ints: UnsafeMutablePointer<Int>! = data.withUnsafeMutableBytes{ $0 }
+        let bytes = OpaquePointer(ints)
+        
+        //load the BlueLightStatus struct into the opaque pointer
+        self.getBlueLightStatus(bytes)
+        
+        //get the byes from the BlueLightStatus pointer
+        let intsArray = [UInt8](data)
+        
+        //it looks like the second byte is a boolean representing if Night Shift is enabled
+        return intsArray[1] == 1
+    }
 }
 
 class StatusMenuController: NSObject {


### PR DESCRIPTION
This PR adds `CBBlueLightClient.isNightShiftEnabled` by mucking around in the `getBlueLightStatus` struct's raw binary:

```swift
var isNightShiftEnabled: Bool {
    //create an empty mutable OpaquePointer
    let string = "0000000000"
    var data = string.data(using: .utf8)!
    let ints: UnsafeMutablePointer<Int>! = data.withUnsafeMutableBytes{ $0 }
    let bytes = OpaquePointer(ints)

    //load the BlueLightStatus struct into the opaque pointer
    self.getBlueLightStatus(bytes)

    //get the byes from the BlueLightStatus pointer
    let intsArray = [UInt8](data)

    //it looks like the second byte is a boolean representing if Night Shift is enabled
    return intsArray[1] == 1
}
```