### PR TITLE
Inform user about unsupported hardware (older Macs)

### DIFF
--- a/Shifty/AppDelegate.swift
+++ b/Shifty/AppDelegate.swift
@@ -37,6 +37,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             NSApplication.shared().terminate(self)
         }
         
+        if !CBBlueLightClient.supportsBlueLightReduction() {
+            Event.unsupportedHardware.record()
+            let alert: NSAlert = NSAlert()
+            alert.messageText = "Your Mac hardware does not support Night Shift"
+            alert.informativeText = "A newer Mac is required to use Shifty."
+            alert.alertStyle = NSAlertStyle.warning
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+            
+            NSApplication.shared().terminate(self)
+        }
+        
         let launcherAppIdentifier = "io.natethompson.ShiftyHelper"
         
         var startedAtLogin = false

--- a/Shifty/CBBlueLightClient.h
+++ b/Shifty/CBBlueLightClient.h
@@ -16,4 +16,5 @@
 - (BOOL)getCCT:(float*)arg1;
 - (BOOL)getBlueLightStatus:(struct { BOOL x1; BOOL x2; BOOL x3; int x4; struct { struct { int x_1_2_1; int x_1_2_2; } x_5_1_1; struct { int x_2_2_1; int x_2_2_2; } x_5_1_2; } x5; unsigned long x6; }*)arg1;
 - (void)setStatusNotificationBlock:(id /* block */)arg1;
++ (BOOL)supportsBlueLightReduction;
 @end

--- a/Shifty/Event.swift
+++ b/Shifty/Event.swift
@@ -13,7 +13,8 @@ import Crashlytics
 enum Event {
     case appLaunched
     case oldMacOSVersion(version: String)
-    
+    case unsupportedHardware
+
     //StatusMenuController
     case toggleNightShift(state: Bool)
     case disableForCurrentApp(state: Bool)
@@ -48,6 +49,7 @@ extension Event {
         switch(self) {
         case .appLaunched: return "App Launched"
         case .oldMacOSVersion(_): return "Unsupported version of macOS"
+        case .unsupportedHardware: return "Unsupported Hardware"
         case .toggleNightShift: return "Night Shift Toggled"
         case .disableForCurrentApp(_): return "Disable for current app clicked"
         case .disableForHour(_): return" Disable for hour clicked"


### PR DESCRIPTION
Slider has no effect in older Macs (e.g. MacBookPro8,x), where Night Mode is not supported even if 
OS is up to date.

Show an alert to the user and terminate app when using older Macs which do
not support Night Mode. Log unsupportedHardware event.