### PR TITLE
Add support for browser exception rules

### DIFF
--- a/Shifty/en.lproj/Localizable.strings
+++ b/Shifty/en.lproj/Localizable.strings
@@ -17,6 +17,9 @@
 "menu.disabled_domain" = "Disabled for %@";
 "menu.disable_subdomain" = "Disable for %@";
 "menu.disabled_subdomain" = "Disabled for %@";
+"menu.enable_subdomain" = "Enable for %@";
+"menu.enabled_subdomain" = "Enabled for %@";
+
 "menu.disable_hour" = "Disable for an hour";
 "menu.disabled_hour" = "Disabled for an hour";
 "menu.disable_custom" = "Disable for custom time...";


### PR DESCRIPTION
If the main domain is disabled, we can enable an exception rule for the subdomain.
If the main domain is disabled and the subdomain is an exception rule, disabling main domain also removes the exception rule.
If the subdomain is disabled, disabling the main domain removes the subdomain disabled rule.
These are assumption made to keep consistency.

Some variables should now probably be renamed to make more sense, and I could probably refactor some code to make it easier to work on it later, but I plan on doing it in a separate refactor PR when I'll have some free time.