### PR TITLE
Use AXValueChanged notification and fix Safari url detection for fullscreen videos

### DIFF
--- a/Shifty/BrowserRule.swift
+++ b/Shifty/BrowserRule.swift
@@ -178,37 +178,14 @@ func checkForBrowserRules(domain: String, subdomain: String, rules: [BrowserRule
 func startBrowserWatcher(_ processIdentifier: pid_t, callback: @escaping () -> Void) throws {
     if let app = Application(forProcessID: processIdentifier) {
         browserObserver = app.createObserver { (observer: Observer, element: UIElement, event: AXNotification, info: [String: AnyObject]?) in
-            if event == .windowCreated {
-                do {
-                    try browserObserver.addNotification(.titleChanged, forElement: element)
-                } catch let error {
-                    NSLog("Error: Could not watch [\(element)]: \(error)")
-                    logw("Error: Could not watch [\(element)]: \(error)")
-                }
-            }
-            if event == .titleChanged || event == .focusedWindowChanged {
+            if event == .valueChanged
+            {
                 DispatchQueue.main.async {
                     callback()
                 }
             }
         }
-        
-        do {
-            let windows = try app.windows()!
-            for window in windows {
-                do {
-                    try browserObserver.addNotification(.titleChanged, forElement: window)
-                } catch let error {
-                    NSLog("Error: Could not watch [\(window)]: \(error)")
-                    logw("Error: Could not watch [\(window)]: \(error)")
-                }
-            }
-        } catch let error {
-            NSLog("Error: Could not get windows for \(app): \(error)")
-            logw("Error: Could not get windows for \(app): \(error)")
-        }
-        try browserObserver.addNotification(.focusedWindowChanged, forElement: app)
-        try browserObserver.addNotification(.windowCreated, forElement: app)
+        try browserObserver.addNotification(.valueChanged, forElement: app)
     }
 }
 


### PR DESCRIPTION
Two commits in this PR.
1- Use the value changed notification instead of listening for window creation and subscribing to the title changed one. This one, at least in my tests, triggers every time the URL changes, even if the title stays the same. This should allows us to make even more powerful rules for the URL in the future as well as making everything more reliable

2- This change is a little more controversial, but it's essential at least for me since it fixes an issue with a Safari feature I use constantly.
Every time you make a video fullscreen in Safari a space is allocated for it, so you have the original tab which contains the video and the fullscreen window that contains only the video.
The scripting bridge API provided by Safari doesn't consider the fullscreen window a standalone window, so it isn't detected when requesting the current tab.
The issue arises when I have a video full screen but the window with the tab that contains the video has another tab selected. In this case the current tab returned is the one in the containing window, not the fullscreen one. I tried every single approach to solve this using the scripting additions, but without luck.
My solution is to traverse the Accessibility hierarchy provided by the AX APIs until we arrive to the UIElement which contains the AXURL attribute, which gives us the tab URL. This solution is less robust than the one before since it relies on hope that the hierarchy doesn't change. But since it's been pretty stable for a while I'm confident.
I also keep the current solution as a fallback, so it'll keep working even then.