### PR TITLE
Cache SBApplication objects

### DIFF
--- a/Shifty/BrowserManager.swift
+++ b/Shifty/BrowserManager.swift
@@ -42,6 +42,7 @@ enum SupportedBrowser: BundleIdentifier {
     }
 }
 
+var cachedBrowsers: [SupportedBrowser: Browser] = [:]
 
 enum BrowserManager {
     static var currentURL: URL? {
@@ -50,10 +51,18 @@ enum BrowserManager {
         }
         
         guard let application = RuleManager.currentApp,
-            let browser = SupportedBrowser(application),
-            let app: Browser = SBApplication(application) else {
+            let browser = SupportedBrowser(application) else {
                 return nil
         }
+        if cachedBrowsers[browser] == nil {
+            guard let bundleID: String = application.bundleIdentifier,
+                  let app: Browser = SBApplication(bundleIdentifier: bundleID) else {
+                return nil
+            }
+            cachedBrowsers[browser] = app
+        }
+        
+        let app = cachedBrowsers[browser]!;
         
         do {
             let url = try urlFor(browser, app)

--- a/Shifty/ScriptingBridge.swift
+++ b/Shifty/ScriptingBridge.swift
@@ -21,9 +21,5 @@ import ScriptingBridge
 	@objc optional var URL: String { get }
 }
 
-extension SBApplication: Browser {
-    convenience init?(_ application: NSRunningApplication) {
-        self.init(processIdentifier: application.processIdentifier)
-    }
-}
+extension SBApplication: Browser { }
 extension SBObject: Window, Tab { }


### PR DESCRIPTION
ScriptingBridge seems to be a known leaky framework, but at least we can try to reduce the leaks amount.
Three simple changes:
1. cache `SBApplication` objects, recreating them each time leaks some memory, and since this happens every time we switch back to a Browser from another application, even if it's only some bytes they start to add up quickly.
1. don't use a custom convenience method, don't know why but it leaks more memory (at least according to Instruments).
2. init `SBApplication` using the `bundleIdentifier` instead of the `pid_t`. This is because if we cache `SBApplication` the object isn't valid anymore once the browser is closed. Restarting a browser still leaks some bytes because why not... but that's something we can probably live with, since it's only 96 bytes every time a browser restarts. (also it doesn't seem to leak those every time, and Safari doesn't seem to be affected by this)

This may fix #63, but there should be probably more people testing this change and see if this is the only leak (or at least the big one)