### PR TITLE
Small ScriptingBridge and AX fixes

### DIFF
--- a/Shifty/BrowserManager.swift
+++ b/Shifty/BrowserManager.swift
@@ -11,6 +11,8 @@ import PublicSuffix
 import SwiftLog
 
 var browserObserver: Observer!
+var observedApp: Application!
+var focusedWindow: UIElement!
 
 enum BrowserError: Error {
     case noWindow
@@ -145,14 +147,23 @@ enum BrowserManager {
     }
     
     private static func startBrowserWatcher(_ processIdentifier: pid_t, callback: @escaping () -> Void) throws {
-        if let app = Application(forProcessID: processIdentifier) {
-            browserObserver = app.createObserver { (observer: Observer, element: UIElement, event: AXNotification, info: [String: AnyObject]?) in
+        observedApp = Application(forProcessID: processIdentifier)
+        if observedApp != nil {
+            browserObserver = observedApp.createObserver { (observer: Observer, element: UIElement, event: AXNotification, info: [String: AnyObject]?) in
                 switch event {
-                case .valueChanged:
+                case .valueChanged, .uiElementDestroyed:
+                    if element == focusedWindow {
+                        fallthrough
+                    }
                     if let role = try? element.role(), role == .staticText {
                         fallthrough
                     }
                 case .focusedWindowChanged:
+                    do {
+                        focusedWindow  = try observedApp.attribute(.focusedWindow)
+                    } catch let error {
+                        logw("Error: Unable to obtain focused window: \(error)")
+                    }
                     DispatchQueue.main.async {
                         callback()
                     }
@@ -160,13 +171,28 @@ enum BrowserManager {
                     logw("Error: Unexpected notification \(event) received")
                 }
             }
-            try browserObserver.addNotification(.valueChanged, forElement: app)
-            try browserObserver.addNotification(.focusedWindowChanged, forElement: app)
+            try browserObserver.addNotification(.valueChanged, forElement: observedApp)
+            try browserObserver.addNotification(.focusedWindowChanged, forElement: observedApp)
+            try browserObserver.addNotification(.uiElementDestroyed, forElement: observedApp)
+            focusedWindow = try observedApp.attribute(.focusedWindow)
         }
     }
     
     static func stopBrowserWatcher() {
         if browserObserver != nil {
+            if observedApp != nil {
+                do {
+                    try browserObserver.removeNotification(.valueChanged, forElement: observedApp)
+                    try browserObserver.removeNotification(.focusedWindowChanged, forElement: observedApp)
+                    try browserObserver.removeNotification(.uiElementDestroyed, forElement: observedApp)
+                } catch let error {
+                    logw("Error: Couldn't remove notifications: \(error)")
+                }
+                observedApp = nil
+            }
+            if focusedWindow != nil {
+                focusedWindow = nil
+            }
             browserObserver.stop()
             browserObserver = nil
         }

--- a/Shifty/BrowserManager.swift
+++ b/Shifty/BrowserManager.swift
@@ -173,7 +173,7 @@ enum BrowserManager {
     }
     
     private static func urlFor(_ browser: SupportedBrowser, _ application: Browser) throws -> URL? {
-        guard let window = (application.windows as? [Window])?.first else {
+        guard let window = (application.windows!() as? [Window])?.first else {
             throw BrowserError.noWindow
         }
         let tab: Tab?

--- a/Shifty/RuleManager.swift
+++ b/Shifty/RuleManager.swift
@@ -222,6 +222,7 @@ enum RuleManager {
     }
 
     private static func appSwitched(notification: Notification) {
+        BrowserManager.stopBrowserWatcher()
         if disabledForApp {
             NightShiftManager.respond(to: .nightShiftDisableRuleActivated)
         } else if BrowserManager.currrentAppIsSupportedBrowser {

--- a/Shifty/ScriptingBridge.swift
+++ b/Shifty/ScriptingBridge.swift
@@ -8,16 +8,26 @@
 import Cocoa
 import ScriptingBridge
 
-@objc protocol Browser {
-	@objc optional var windows: SBElementArray { get }
+@objc public protocol SBObjectProtocol: NSObjectProtocol {
+    func get() -> Any!
 }
 
-@objc protocol Window {
+@objc public protocol SBApplicationProtocol: SBObjectProtocol {
+    func activate()
+    var delegate: SBApplicationDelegate! { get set }
+    var isRunning: Bool { get }
+}
+
+@objc protocol Browser : SBApplicationProtocol {
+    @objc optional func windows() -> SBElementArray
+}
+
+@objc protocol Window : SBObjectProtocol {
 	@objc optional var currentTab: Tab { get }
 	@objc optional var activeTab: Tab { get }
 }
 
-@objc protocol Tab {
+@objc protocol Tab : SBObjectProtocol {
 	@objc optional var URL: String { get }
 }
 


### PR DESCRIPTION
Some more fixes for the next release.

1. Fix more leaks when using ScriptingBridge
2. Stop browser watcher when switching applications (this was probably forgotten when you refactored the code)
3. Remove the notifications we registered (should mitigate https://github.com/tmandry/AXSwift/issues/11) and also register notification for when a window is destroyed

P.S. Completely off topic, but thank you for making me a collaborator!