### PR TITLE
Fix Chrome reopening

### DIFF
--- a/Shifty/NightShiftManager.swift
+++ b/Shifty/NightShiftManager.swift
@@ -360,7 +360,6 @@ enum NightShiftManager {
             } else {
                 setToSchedule()
             }
-            print(RuleManager.ruleForSubdomain)
         case .nightShiftDisableTimerStarted:
             isNightShiftEnabled = false
         case .nightShiftDisableTimerEnded:


### PR DESCRIPTION
Due to a race condition between `ScriptingBridge` and `NSWorkspace` APIs, we
may have an `NSRunningApplication` as the active application, but a non
running `SBApplication` object. In Chrome, when a method is called on this
object (like `windows()`) `ScriptingBridge` will relaunch the application.
To solve this we just check if the `SBApplication` is running.

@thompsonate  You should probably make a quick release for this, seems super annoying.