### PR TITLE
Speculative fix for crashes in libswiftFoundation.dylib

### DIFF
--- a/Shifty/BrowserManager.swift
+++ b/Shifty/BrowserManager.swift
@@ -242,7 +242,7 @@ enum BrowserManager {
             logw("Error: Could not get url, app already closed")
             return nil
         }
-        guard let window = (browser.windows?() as? [Window])?.first else {
+        guard let windows = browser.windows?(), windows.count > 0, let window = windows[0] as? Window else {
             logw("Error: Could not get url, there are no windows")
             return nil
         }


### PR DESCRIPTION
Speculative fix for crashes caused by Foundation failing to bridge an Obj-C NSArray to a Swift array.

[Shifty 1.1 Crash.txt](https://github.com/thompsonate/Shifty/files/3205557/Shifty.1.1.Crash.txt)
