### PR TITLE
Add missing field to CBBlueLight Status

### DIFF
--- a/Shifty/CBBlueLightClient.h
+++ b/Shifty/CBBlueLightClient.h
@@ -28,6 +28,7 @@ typedef struct {
     int mode;
     Schedule schedule;
     unsigned long long disableFlags;
+    BOOL available;
 } Status;
 
 - (BOOL)setStrength:(float)strength commit:(BOOL)commit;


### PR DESCRIPTION
Since macOS 10.14.6 and 10.15 the `CBBlueLight` `Status` struct has changed, adding an additional field.
When calling `getBlueLightStatus` some unrelated data would then get overwritten, leading to a crash. This fixes #86 
This should also be safe on older versions (we are just providing a bigger struct there, so no issues)