### PR TITLE
Improved Dark Mode Toggle functionality

### DIFF
--- a/Shifty/AppDelegate.swift
+++ b/Shifty/AppDelegate.swift
@@ -235,7 +235,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             statusItem.button?.performClick(self)
             statusItem.menu = nil
         } else if event.type == .leftMouseUp {
-            statusItemClicked?()
+            if event.modifierFlags.contains(.shift) {
+                SLSSetAppearanceThemeLegacy(!SLSGetAppearanceThemeLegacy())
+            } else {
+                statusItemClicked?()
+            }
         }
     }
 

--- a/Shifty/AppDelegate.swift
+++ b/Shifty/AppDelegate.swift
@@ -234,7 +234,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             statusItem.menu = statusMenu
             statusItem.button?.performClick(self)
             statusItem.menu = nil
-        } else if event.type == .leftMouseUp {
+        } else if event.type == .leftMouseDown {
             if event.modifierFlags.contains(.shift) {
                 SLSSetAppearanceThemeLegacy(!SLSGetAppearanceThemeLegacy())
             } else {

--- a/Shifty/Base.lproj/PrefGeneralViewController.xib
+++ b/Shifty/Base.lproj/PrefGeneralViewController.xib
@@ -29,14 +29,14 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <view wantsLayer="YES" id="bXz-rK-jao">
-            <rect key="frame" x="0.0" y="0.0" width="349" height="409"/>
+            <rect key="frame" x="0.0" y="0.0" width="349" height="421"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lTA-eh-l51">
-                    <rect key="frame" x="20" y="115" width="309" height="274"/>
+                    <rect key="frame" x="20" y="113" width="309" height="288"/>
                     <subviews>
                         <button horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JqG-nx-58t">
-                            <rect key="frame" x="-2" y="258" width="154" height="18"/>
+                            <rect key="frame" x="-2" y="272" width="154" height="18"/>
                             <buttonCell key="cell" type="check" title="Launch Shifty at login" bezelStyle="regularSquare" imagePosition="left" inset="2" id="bxC-lM-Pei">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -49,10 +49,10 @@
                             </connections>
                         </button>
                         <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Rnx-9y-VnG">
-                            <rect key="frame" x="0.0" y="206" width="309" height="46"/>
+                            <rect key="frame" x="0.0" y="206" width="309" height="60"/>
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KNx-x5-o3g">
-                                    <rect key="frame" x="-2" y="30" width="102" height="18"/>
+                                    <rect key="frame" x="-2" y="44" width="102" height="18"/>
                                     <buttonCell key="cell" type="check" title="Quick Toggle" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Foo-g6-6iX">
                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                         <font key="font" metaFont="system"/>
@@ -65,9 +65,9 @@
                                     </connections>
                                 </button>
                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="6yx-Be-Jx5">
-                                    <rect key="frame" x="18" y="0.0" width="293" height="28"/>
-                                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="If enabled, click the Menu Bar icon to toggle Night Shift. Right click to open the menu." id="MXt-WM-cMR">
-                                        <font key="font" metaFont="smallSystem"/>
+                                    <rect key="frame" x="18" y="0.0" width="293" height="42"/>
+                                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="If enabled, click the Menu Bar icon to toggle Night Shift or shift-click to toggle Dark Mode. Right click to open the menu." id="MXt-WM-cMR">
+                                        <font key="font" metaFont="message" size="11"/>
                                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
@@ -239,19 +239,19 @@
                     </customSpacing>
                 </stackView>
                 <box horizontalHuggingPriority="1000" verticalHuggingPriority="1000" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="Xwu-c8-3l2">
-                    <rect key="frame" x="17" y="16" width="315" height="81"/>
+                    <rect key="frame" x="17" y="16" width="315" height="79"/>
                     <view key="contentView" id="M39-xI-Ibk">
-                        <rect key="frame" x="3" y="3" width="309" height="75"/>
+                        <rect key="frame" x="3" y="3" width="309" height="73"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RlH-eS-o9O">
-                                <rect key="frame" x="0.0" y="10" width="309" height="55"/>
+                                <rect key="frame" x="0.0" y="10" width="309" height="53"/>
                                 <subviews>
                                     <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DwA-jT-rcV">
-                                        <rect key="frame" x="10" y="34" width="289" height="21"/>
+                                        <rect key="frame" x="10" y="34" width="289" height="19"/>
                                         <subviews>
                                             <textField horizontalHuggingPriority="1000" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="cgx-4b-v1c">
-                                                <rect key="frame" x="-2" y="2" width="65" height="19"/>
+                                                <rect key="frame" x="-2" y="3" width="65" height="16"/>
                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Schedule:" id="UGI-RO-ff6">
                                                     <font key="font" metaFont="system"/>
                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -259,7 +259,7 @@
                                                 </textFieldCell>
                                             </textField>
                                             <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vul-m7-WVn">
-                                                <rect key="frame" x="67" y="-3" width="225" height="25"/>
+                                                <rect key="frame" x="67" y="-3" width="225" height="23"/>
                                                 <popUpButtonCell key="cell" type="push" title="Off" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="lkN-xJ-pf3" id="kHG-4E-c49">
                                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="menu"/>
@@ -292,10 +292,10 @@
                                         <rect key="frame" x="0.0" y="0.0" width="299" height="24"/>
                                         <subviews>
                                             <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d8y-sn-Tbn">
-                                                <rect key="frame" x="0.0" y="0.0" width="161" height="24"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="162" height="24"/>
                                                 <subviews>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Pyo-AD-ZFn">
-                                                        <rect key="frame" x="-2" y="3" width="75" height="17"/>
+                                                        <rect key="frame" x="-2" y="4" width="75" height="16"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="From:" id="PbT-Ky-Re6">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -303,7 +303,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <datePicker verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uxU-uR-S3U">
-                                                        <rect key="frame" x="79" y="0.0" width="85" height="28"/>
+                                                        <rect key="frame" x="79" y="0.0" width="86" height="28"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="uxU-uR-S3U" secondAttribute="height" multiplier="80:23" id="613-kZ-g5A"/>
                                                         </constraints>
@@ -337,10 +337,10 @@
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HzU-vh-YBc">
-                                                <rect key="frame" x="169" y="0.0" width="130" height="24"/>
+                                                <rect key="frame" x="170" y="0.0" width="129" height="24"/>
                                                 <subviews>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kBV-5Y-V1o">
-                                                        <rect key="frame" x="-2" y="3" width="44" height="17"/>
+                                                        <rect key="frame" x="-2" y="4" width="42" height="16"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="to:" id="aNq-H7-I2m">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -348,7 +348,7 @@
                                                         </textFieldCell>
                                                     </textField>
                                                     <datePicker verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ddu-sM-B7W">
-                                                        <rect key="frame" x="48" y="0.0" width="85" height="28"/>
+                                                        <rect key="frame" x="46" y="0.0" width="86" height="28"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="ddu-sM-B7W" secondAttribute="height" multiplier="80:23" id="aED-iS-yOj"/>
                                                         </constraints>
@@ -418,7 +418,7 @@
                     </view>
                 </box>
                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="X5z-4y-ROF">
-                    <rect key="frame" x="303" y="105" width="32" height="31"/>
+                    <rect key="frame" x="303" y="103" width="32" height="31"/>
                     <buttonCell key="cell" type="round" title="i" bezelStyle="circular" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="jjX-rt-8G1">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" size="13" name="TimesNewRomanPS-ItalicMT"/>

--- a/Shifty/MainMenu.xib
+++ b/Shifty/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>

--- a/Shifty/MainMenu.xib
+++ b/Shifty/MainMenu.xib
@@ -36,6 +36,7 @@
                 <outlet property="sliderView" destination="xRd-3s-8Ep" id="5v2-aR-QE3"/>
                 <outlet property="statusMenu" destination="YaK-8p-dol" id="uua-tx-AWw"/>
                 <outlet property="sunIcon" destination="Dky-H2-15i" id="AXj-lL-QbW"/>
+                <outlet property="toggleDarkModeMenuItem" destination="jGP-GB-0Cw" id="Dsk-Ir-TZH"/>
                 <outlet property="trueToneMenuItem" destination="fW8-W0-ja9" id="idL-jg-jCv"/>
             </connections>
         </customObject>
@@ -45,6 +46,12 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="power:" target="YHE-ZD-Fjn" id="JXj-lp-mVz"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Toggle Dark Mode" id="jGP-GB-0Cw">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="toggleDarkMode:" target="YHE-ZD-Fjn" id="idq-eu-ERd"/>
                     </connections>
                 </menuItem>
                 <menuItem title="Description" id="zi6-lD-Hd5">

--- a/Shifty/NightShiftManager.swift
+++ b/Shifty/NightShiftManager.swift
@@ -263,14 +263,15 @@ enum NightShiftManager {
                 prevSchedule = schedule
             }
             
-            let appDelegate = NSApplication.shared.delegate as! AppDelegate
-            appDelegate.updateMenuBarIcon()
-            
-            let prefWindow = (NSApplication.shared.delegate as? AppDelegate)?.preferenceWindowController
-            let prefGeneral = prefWindow?.viewControllers.compactMap { childViewController in
-                return childViewController as? PrefGeneralViewController
-                }.first
             DispatchQueue.main.async {
+                let appDelegate = NSApplication.shared.delegate as! AppDelegate
+                appDelegate.updateMenuBarIcon()
+                
+                let prefWindow = (NSApplication.shared.delegate as? AppDelegate)?.preferenceWindowController
+                let prefGeneral = prefWindow?.viewControllers.compactMap { childViewController in
+                    return childViewController as? PrefGeneralViewController
+                    }.first
+                
                 prefGeneral?.updateSchedule?()
             }
             

--- a/Shifty/StatusMenuController.swift
+++ b/Shifty/StatusMenuController.swift
@@ -82,6 +82,7 @@ class StatusMenuController: NSObject, NSMenuDelegate {
         descriptionMenuItem.isEnabled = false
         sliderMenuItem.view = sliderView
 
+        toggleDarkModeMenuItem.title = NSLocalizedString("menu.toggle_dark_mode", comment: "Toggle Dark Mode")
         disableHourMenuItem.title = NSLocalizedString("menu.disable_hour", comment: "Disable for an hour")
         disableCustomMenuItem.title = NSLocalizedString("menu.disable_custom", comment: "Disable for custom time...")
         preferencesMenuItem.title = NSLocalizedString("menu.preferences", comment: "Preferences...")

--- a/Shifty/StatusMenuController.swift
+++ b/Shifty/StatusMenuController.swift
@@ -15,6 +15,7 @@ class StatusMenuController: NSObject, NSMenuDelegate {
 
     @IBOutlet weak var statusMenu: NSMenu!
     @IBOutlet weak var powerMenuItem: NSMenuItem!
+    @IBOutlet weak var toggleDarkModeMenuItem: NSMenuItem!
     @IBOutlet weak var trueToneMenuItem: NSMenuItem!
     @IBOutlet weak var sliderMenuItem: NSMenuItem!
     @IBOutlet weak var descriptionMenuItem: NSMenuItem!
@@ -386,6 +387,12 @@ class StatusMenuController: NSObject, NSMenuDelegate {
         } else {
             NightShiftManager.respond(to: .userEnabledNightShift)
         }
+    }
+    
+    
+    
+    @IBAction func toggleDarkMode(_ sender: Any) {
+        SLSSetAppearanceThemeLegacy(!SLSGetAppearanceThemeLegacy())
     }
     
     

--- a/Shifty/de.lproj/Localizable.strings
+++ b/Shifty/de.lproj/Localizable.strings
@@ -15,6 +15,7 @@
 "menu.disabled_for" = "Deaktiviert für %@";
 "menu.enable_for" = "Aktivieren für %@";
 "menu.enabled_for" = "Aktiviert für %@";
+"menu.toggle_dark_mode" = "Dark Mode umschalten"
 
 "menu.disable_running_app" = "Deaktivieren, wenn %@ läuft";
 "menu.disabled_running_app" = "Deaktivieren, wenn %@ läuft";

--- a/Shifty/de.lproj/Localizable.strings
+++ b/Shifty/de.lproj/Localizable.strings
@@ -15,7 +15,7 @@
 "menu.disabled_for" = "Deaktiviert für %@";
 "menu.enable_for" = "Aktivieren für %@";
 "menu.enabled_for" = "Aktiviert für %@";
-"menu.toggle_dark_mode" = "Dark Mode umschalten"
+"menu.toggle_dark_mode" = "Dark Mode umschalten";
 
 "menu.disable_running_app" = "Deaktivieren, wenn %@ läuft";
 "menu.disabled_running_app" = "Deaktivieren, wenn %@ läuft";

--- a/Shifty/de.lproj/PrefGeneralViewController.strings
+++ b/Shifty/de.lproj/PrefGeneralViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSButtonCell"; title = "Website Shifting"; ObjectID = "HRq-mZ-FxG"; */
 "HRq-mZ-FxG.title" = "Webseiten-Shift";
 
-/* Class = "NSTextFieldCell"; title = "If enabled, click the Menu Bar icon to toggle Night Shift. Right click to open the menu."; ObjectID = "MXt-WM-cMR"; */
-"MXt-WM-cMR.title" = "Wenn aktiviert kann Night Shift bei Klick auf das Menüleisten-Symbol schnell umgeschaltet werden. Ein Rechtsklick auf das Symbol öffnet das Menü.";
+/* Class = "NSTextFieldCell"; title = "If enabled, click the Menu Bar icon to toggle Night Shift or shift-click to toggle Dark Mode. Right click to open the menu."; ObjectID = "MXt-WM-cMR"; */
+"MXt-WM-cMR.title" = "Wenn aktiviert kann Night Shift bei Klick auf das Menüleisten-Symbol sowie Dark Mode bei Shift-Klick umgeschaltet werden. Ein Rechtsklick auf das Symbol öffnet das Menü.";
 
 /* Class = "NSTextFieldCell"; title = "From:"; ObjectID = "PbT-Ky-Re6"; */
 "PbT-Ky-Re6.title" = "Von:";

--- a/Shifty/en.lproj/Localizable.strings
+++ b/Shifty/en.lproj/Localizable.strings
@@ -15,6 +15,7 @@
 "menu.disabled_for" = "Disabled for %@";
 "menu.enable_for" = "Enable for %@";
 "menu.enabled_for" = "Enabled for %@";
+"menu.toggle_dark_mode" = "Toggle Dark Mode"
 
 "menu.disable_running_app" = "Disable when %@ is running";
 "menu.disabled_running_app" = "Disabled when %@ is running";

--- a/Shifty/en.lproj/Localizable.strings
+++ b/Shifty/en.lproj/Localizable.strings
@@ -15,7 +15,7 @@
 "menu.disabled_for" = "Disabled for %@";
 "menu.enable_for" = "Enable for %@";
 "menu.enabled_for" = "Enabled for %@";
-"menu.toggle_dark_mode" = "Toggle Dark Mode"
+"menu.toggle_dark_mode" = "Toggle Dark Mode";
 
 "menu.disable_running_app" = "Disable when %@ is running";
 "menu.disabled_running_app" = "Disabled when %@ is running";

--- a/Shifty/en.lproj/PrefGeneralViewController.strings
+++ b/Shifty/en.lproj/PrefGeneralViewController.strings
@@ -1,53 +1,54 @@
+
 /* Class = "NSButtonCell"; title = "True Tone control"; ObjectID = "4SC-bL-79S"; */
-"4SC-bL-79S.title" = "Contrôle True Tone";
+"4SC-bL-79S.title" = "True Tone control";
 
 /* Class = "NSButtonCell"; title = "Set menu bar icon according to Night Shift"; ObjectID = "4io-9H-HXp"; */
-"4io-9H-HXp.title" = "Changer l'icône de la barre des menus selon Night Shift";
+"4io-9H-HXp.title" = "Set menu bar icon according to Night Shift";
 
 /* Class = "NSButtonCell"; title = "Scheduled Dark Mode"; ObjectID = "5s5-Y5-5b9"; */
-"5s5-Y5-5b9.title" = "Programmer le mode foncé";
+"5s5-Y5-5b9.title" = "Scheduled Dark Mode";
 
 /* Class = "NSMenuItem"; title = "Custom"; ObjectID = "Cum-ew-Bk2"; */
-"Cum-ew-Bk2.title" = "Personnalisé";
+"Cum-ew-Bk2.title" = "Custom";
 
 /* Class = "NSButtonCell"; title = "Quick Toggle"; ObjectID = "Foo-g6-6iX"; */
-"Foo-g6-6iX.title" = "Changement rapide";
+"Foo-g6-6iX.title" = "Quick Toggle";
 
 /* Class = "NSButtonCell"; title = "Website Shifting"; ObjectID = "HRq-mZ-FxG"; */
-"HRq-mZ-FxG.title" = "Permutation des sites web";
+"HRq-mZ-FxG.title" = "Website Shifting";
 
 /* Class = "NSTextFieldCell"; title = "If enabled, click the Menu Bar icon to toggle Night Shift or shift-click to toggle Dark Mode. Right click to open the menu."; ObjectID = "MXt-WM-cMR"; */
-"MXt-WM-cMR.title" = "Si activé, un clic sur l’icône dans la barre des menus changera l'état de Night Shift, le clic de changement change le Dark Mode. Un clic droit ouvre le menu.";
+"MXt-WM-cMR.title" = "If enabled, click the Menu Bar icon to toggle Night Shift or shift-click to toggle Dark Mode. Right click to open the menu.";
 
 /* Class = "NSTextFieldCell"; title = "From:"; ObjectID = "PbT-Ky-Re6"; */
-"PbT-Ky-Re6.title" = "De :";
+"PbT-Ky-Re6.title" = "From:";
 
 /* Class = "NSTextFieldCell"; title = "If enabled, Night Shift rules for apps and websites will also affect True Tone."; ObjectID = "SKw-93-vs8"; */
-"SKw-93-vs8.title" = "Si activé, les règles Night Shift pour les applications et les sites web affecteront également True Tone.";
+"SKw-93-vs8.title" = "If enabled, Night Shift rules for apps and websites will also affect True Tone.";
 
 /* Class = "NSMenuItem"; title = "Sunset to Sunrise"; ObjectID = "TwI-wC-vyX"; */
-"TwI-wC-vyX.title" = "Du coucher au lever du soleil";
+"TwI-wC-vyX.title" = "Sunset to Sunrise";
 
 /* Class = "NSTextFieldCell"; title = "Schedule:"; ObjectID = "UGI-RO-ff6"; */
-"UGI-RO-ff6.title" = "Programmation :";
+"UGI-RO-ff6.title" = "Schedule:";
 
 /* Class = "NSTextFieldCell"; title = "If enabled, macOS Dark Mode will be automatically set based on the Night Shift schedule."; ObjectID = "ZdB-dN-hiO"; */
-"ZdB-dN-hiO.title" = "Si activé, le mode foncé de macOS sera activé en fonction de l’état de Night Shift.";
+"ZdB-dN-hiO.title" = "If enabled, macOS Dark Mode will be automatically set based on the Night Shift schedule.";
 
 /* Class = "NSTextFieldCell"; title = "to:"; ObjectID = "aNq-H7-I2m"; */
-"aNq-H7-I2m.title" = "à :";
+"aNq-H7-I2m.title" = "to:";
 
 /* Class = "NSButtonCell"; title = "Share anonymous crash data and analytics"; ObjectID = "ar0-8I-WmN"; */
-"ar0-8I-WmN.title" = "Partager les rapports d'erreur et les statistiques anonymement";
+"ar0-8I-WmN.title" = "Share anonymous crash data and analytics";
 
 /* Class = "NSButtonCell"; title = "Launch Shifty at login"; ObjectID = "bxC-lM-Pei"; */
-"bxC-lM-Pei.title" = "Lancer Shifty au démarrage";
+"bxC-lM-Pei.title" = "Launch Shifty at login";
 
 /* Class = "NSTextFieldCell"; title = "If enabled, you can set Night Shift to automatically disable when you visit certain websites."; ObjectID = "dvg-gw-YMI"; */
-"dvg-gw-YMI.title" = "Si activé, vous pouvez définir Night Shift pour désactiver automatiquement lorsque vous visitez certains sites Web.";
+"dvg-gw-YMI.title" = "If enabled, you can set Night Shift to automatically disable when you visit certain websites.";
 
 /* Class = "NSButtonCell"; title = "i"; ObjectID = "jjX-rt-8G1"; */
 "jjX-rt-8G1.title" = "i";
 
 /* Class = "NSMenuItem"; title = "Off"; ObjectID = "lkN-xJ-pf3"; */
-"lkN-xJ-pf3.title" = "Désactivé";
+"lkN-xJ-pf3.title" = "Off";

--- a/Shifty/fr.lproj/Localizable.strings
+++ b/Shifty/fr.lproj/Localizable.strings
@@ -15,7 +15,7 @@
 "menu.disabled_for" = "Désactivé pendant %@";
 "menu.enable_for" = "Activer pendant %@";
 "menu.enabled_for" = "Activé pendant %@";
-"menu.toggle_dark_mode" = "Bascule Dark Mode"
+"menu.toggle_dark_mode" = "Bascule Dark Mode";
 
 "menu.disable_running_app" = "Désactiver pour %@";
 "menu.disabled_running_app" = "Désactivé pour %@";

--- a/Shifty/fr.lproj/Localizable.strings
+++ b/Shifty/fr.lproj/Localizable.strings
@@ -15,6 +15,7 @@
 "menu.disabled_for" = "Désactivé pendant %@";
 "menu.enable_for" = "Activer pendant %@";
 "menu.enabled_for" = "Activé pendant %@";
+"menu.toggle_dark_mode" = "Bascule Dark Mode"
 
 "menu.disable_running_app" = "Désactiver pour %@";
 "menu.disabled_running_app" = "Désactivé pour %@";

--- a/Shifty/fr.lproj/PrefGeneralViewController.strings
+++ b/Shifty/fr.lproj/PrefGeneralViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSButtonCell"; title = "Website Shifting"; ObjectID = "HRq-mZ-FxG"; */
 "HRq-mZ-FxG.title" = "Permutation des sites web";
 
-/* Class = "NSTextFieldCell"; title = "If enabled, click the Menu Bar icon to toggle Night Shift. Right click to open the menu."; ObjectID = "MXt-WM-cMR"; */
+/* Class = "NSTextFieldCell"; title = "If enabled, click the Menu Bar icon to toggle Night Shift or shift-click to toggle Dark Mode. Right click to open the menu."; ObjectID = "MXt-WM-cMR"; */
 "MXt-WM-cMR.title" = "Si activé, un clic sur l’icône dans la barre des menus changera l'état de Night Shift. Un clic droit ouvre le menu.";
 
 /* Class = "NSTextFieldCell"; title = "From:"; ObjectID = "PbT-Ky-Re6"; */

--- a/Shifty/ru.lproj/Localizable.strings
+++ b/Shifty/ru.lproj/Localizable.strings
@@ -15,6 +15,7 @@
 "menu.disabled_for" = "Выключено для %@";
 "menu.enable_for" = "Включить для %@";
 "menu.enabled_for" = "Включено для %@";
+"menu.toggle_dark_mode" = "Переключить Dark Mode"
 
 "menu.disable_running_app" = "Выключить, когда %@ работает";
 "menu.disabled_running_app" = "Выключено, когда %@ работает";

--- a/Shifty/ru.lproj/Localizable.strings
+++ b/Shifty/ru.lproj/Localizable.strings
@@ -15,7 +15,7 @@
 "menu.disabled_for" = "Выключено для %@";
 "menu.enable_for" = "Включить для %@";
 "menu.enabled_for" = "Включено для %@";
-"menu.toggle_dark_mode" = "Переключить Dark Mode"
+"menu.toggle_dark_mode" = "Переключить Dark Mode";
 
 "menu.disable_running_app" = "Выключить, когда %@ работает";
 "menu.disabled_running_app" = "Выключено, когда %@ работает";

--- a/Shifty/ru.lproj/PrefGeneralViewController.strings
+++ b/Shifty/ru.lproj/PrefGeneralViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSButtonCell"; title = "Website Shifting"; ObjectID = "HRq-mZ-FxG"; */
 "HRq-mZ-FxG.title" = "Переключение на сайтах";
 
-/* Class = "NSTextFieldCell"; title = "If enabled, click the Menu Bar icon to toggle Night Shift. Right click to open the menu."; ObjectID = "MXt-WM-cMR"; */
+/* Class = "NSTextFieldCell"; title = "If enabled, click the Menu Bar icon to toggle Night Shift or shift-click to toggle Dark Mode. Right click to open the menu."; ObjectID = "MXt-WM-cMR"; */
 "MXt-WM-cMR.title" = "Если включено, то нажмите на иконку в строку меню, чтобы включить Night Shift. Нажмите правой кнопкой мыши, чтобы открыть меню.";
 
 /* Class = "NSTextFieldCell"; title = "From:"; ObjectID = "PbT-Ky-Re6"; */

--- a/Shifty/ru.lproj/PrefGeneralViewController.strings
+++ b/Shifty/ru.lproj/PrefGeneralViewController.strings
@@ -17,7 +17,7 @@
 "HRq-mZ-FxG.title" = "Переключение на сайтах";
 
 /* Class = "NSTextFieldCell"; title = "If enabled, click the Menu Bar icon to toggle Night Shift or shift-click to toggle Dark Mode. Right click to open the menu."; ObjectID = "MXt-WM-cMR"; */
-"MXt-WM-cMR.title" = "Если включено, то нажмите на иконку в строку меню, чтобы включить Night Shift. Нажмите правой кнопкой мыши, чтобы открыть меню.";
+"MXt-WM-cMR.title" = "Если включено, то нажмите на иконку в строку меню, чтобы включить Night Shift, нажмите Shift, чтобы переключить Dark Mode. Нажмите правой кнопкой мыши, чтобы открыть меню.";
 
 /* Class = "NSTextFieldCell"; title = "From:"; ObjectID = "PbT-Ky-Re6"; */
 "PbT-Ky-Re6.title" = "С:";

--- a/Shifty/zh-Hans.lproj/Localizable.strings
+++ b/Shifty/zh-Hans.lproj/Localizable.strings
@@ -15,6 +15,7 @@
 "menu.disabled_for" = "已为%@关闭“夜览”模式";
 "menu.enable_for" = "为%@开启“夜览”模式";
 "menu.enabled_for" = "已为%@开启“夜览”模式";
+"menu.toggle_dark_mode" = "切换黑暗模式"
 
 "menu.disable_running_app" = "当运行%@时禁用";
 "menu.disabled_running_app" = "已在运行%@时禁用";

--- a/Shifty/zh-Hans.lproj/Localizable.strings
+++ b/Shifty/zh-Hans.lproj/Localizable.strings
@@ -15,7 +15,7 @@
 "menu.disabled_for" = "已为%@关闭“夜览”模式";
 "menu.enable_for" = "为%@开启“夜览”模式";
 "menu.enabled_for" = "已为%@开启“夜览”模式";
-"menu.toggle_dark_mode" = "切换黑暗模式"
+"menu.toggle_dark_mode" = "切换黑暗模式";
 
 "menu.disable_running_app" = "当运行%@时禁用";
 "menu.disabled_running_app" = "已在运行%@时禁用";

--- a/Shifty/zh-Hans.lproj/PrefGeneralViewController.strings
+++ b/Shifty/zh-Hans.lproj/PrefGeneralViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSButtonCell"; title = "Website Shifting"; ObjectID = "HRq-mZ-FxG"; */
 "HRq-mZ-FxG.title" = "网站色温调节";
 
-/* Class = "NSTextFieldCell"; title = "If enabled, click the Menu Bar icon to toggle Night Shift. Right click to open the menu."; ObjectID = "MXt-WM-cMR"; */
+/* Class = "NSTextFieldCell"; title = "If enabled, click the Menu Bar icon to toggle Night Shift or shift-click to toggle Dark Mode. Right click to open the menu."; ObjectID = "MXt-WM-cMR"; */
 "MXt-WM-cMR.title" = "启用后，单击菜单栏图标以切换“夜览”模式。辅助点按以打开菜单。";
 
 /* Class = "NSTextFieldCell"; title = "From:"; ObjectID = "PbT-Ky-Re6"; */

--- a/Shifty/zh-Hans.lproj/PrefGeneralViewController.strings
+++ b/Shifty/zh-Hans.lproj/PrefGeneralViewController.strings
@@ -17,7 +17,7 @@
 "HRq-mZ-FxG.title" = "网站色温调节";
 
 /* Class = "NSTextFieldCell"; title = "If enabled, click the Menu Bar icon to toggle Night Shift or shift-click to toggle Dark Mode. Right click to open the menu."; ObjectID = "MXt-WM-cMR"; */
-"MXt-WM-cMR.title" = "启用后，单击菜单栏图标以切换“夜览”模式。辅助点按以打开菜单。";
+"MXt-WM-cMR.title" = "启用后，单击菜单栏图标以切换“夜览”模式, 按住换档按钮单击以切换“暗模式”。辅助点按以打开菜单。";
 
 /* Class = "NSTextFieldCell"; title = "From:"; ObjectID = "PbT-Ky-Re6"; */
 "PbT-Ky-Re6.title" = "从:";


### PR DESCRIPTION
Hello!
Great project, been using it for quite some time. I added some improved Dark Mode functionality because this was missing for me and this now gives me improved usability.

1. New menu bar entry "Toggle Dark Mode" to switch easily between dark/light mode. I didn't feel the need to add state to this entry (e.g. contextual "Turn on..." and "Turn off..." as it is with the Night Shift menu bar entry) because the Dark Mode is clearly visible on the OS. Also added proper localization.

2. Added functionality to the Quick Toggle: when activated, Shift-clicking the menu bar icon toggles Dark Mode. Added description to the preferences entry to reflect this change with proper localization.

3. Changed the .leftMouseUp event listener to leftMouseDown, worked much more reliable on my MacBook Pro trackpad.

Overall just small changes, but this improved the app for me a lot and I thought I might share it with everyone, in case you find this useful too!

Tested with macOS Catalina 10.15.4

![Screen Shot 2020-05-27 at 13 44 14](https://user-images.githubusercontent.com/721715/83015144-4083d280-a020-11ea-84a0-43d2c6840044.png)

